### PR TITLE
Small T-72 fixes

### DIFF
--- a/Prefabs/Vehicles/Core/ERA/Kontakt_Base.et
+++ b/Prefabs/Vehicles/Core/ERA/Kontakt_Base.et
@@ -2,6 +2,7 @@ GenericEntity : "{A507D9AE39652BD6}Prefabs/Vehicles/Core/Vehicle_Part_Base.et" {
  ID "4B42E71698F5739C"
  components {
   BaseTriggerComponent "{5E9ACCBFF26C5062}" {
+   Enabled 0
    PROJECTILE_EFFECTS {
     ExplosionEffect "{5E9ACCBFFB4C405D}" {
      EffectPrefab "{5DC37534B7C424D8}Prefabs/Weapons/Warheads/Warhead_ERA_Kontakt.et"
@@ -17,18 +18,19 @@ GenericEntity : "{A507D9AE39652BD6}Prefabs/Vehicles/Core/Vehicle_Part_Base.et" {
    "Additional hit zones" {
     SCR_MineHitZone ERA {
      ColliderNames {
-      "UTM_Kontakt"
      }
      HZDefault 1
-     DamageReduction 10
-     DamageThreshold 0
-     "Collision multiplier" 0.01
+     MaxHealth 10
+     DamageReduction 20
+     DamageThreshold 8
+     "Collision multiplier" 0
      "Melee multiplier" 0
-     "Kinetic multiplier" 0.01
+     "Kinetic multiplier" 1.2
      "Fragmentation multiplier" 0
-     "Explosive multiplier" 0.005
+     "Explosive multiplier" 1
     }
    }
   }
  }
+ coords 1292.097 37.78 2866.586
 }

--- a/Prefabs/Vehicles/Tracked/T-72A/T72A_FIA.et
+++ b/Prefabs/Vehicles/Tracked/T-72A/T72A_FIA.et
@@ -12,11 +12,6 @@ Tank : "{BC07885176C7FF8A}Prefabs/Vehicles/Tracked/T-72A/T72A_base.et" {
   SCR_EditableVehicleComponent "{50DEB7C26B5EB312}" {
    m_UIInfo SCR_EditableVehicleUIInfo "{5298E609432D192D}" {
     m_sFaction "FIA"
-    m_aAuthoredLabels +{
-    }
-    m_aAutoLabels {
-     12 122 54
-    }
    }
   }
   SCR_VehicleFactionAffiliationComponent "{5882CBD9AC741CEC}" {

--- a/Prefabs/Vehicles/Tracked/T-72A/T72A_FIA.et.meta
+++ b/Prefabs/Vehicles/Tracked/T-72A/T72A_FIA.et.meta
@@ -11,5 +11,7 @@ MetaFileClass {
   }
   EntityTemplateResourceClass HEADLESS : PC {
   }
+  EntityTemplateResourceClass PS5 : PC {
+  }
  }
 }

--- a/Prefabs/Vehicles/Tracked/T-72A/T72A_base.et
+++ b/Prefabs/Vehicles/Tracked/T-72A/T72A_base.et
@@ -252,7 +252,7 @@ Tank : "{8A883ABED22B6E27}Prefabs/Vehicles/Core/Tracked_Base.et" {
      20 21 1001
     }
     m_aAutoLabels {
-     10 122 54
+     10 122 53
     }
     m_EntityBudgetCost {
      SCR_EntityBudgetValue "{5EDC86E4AF8908B6}" {
@@ -330,8 +330,10 @@ Tank : "{8A883ABED22B6E27}Prefabs/Vehicles/Core/Tracked_Base.et" {
      }
     }
     m_Size SLOT_3x3
-    m_bDraggable 0
+    m_bDraggable 1
+    m_bStackable 0
    }
+   StoragePurpose 9
    UseCapacityCoefficient 0
    MaxCumulativeVolume 30000
    MaxItemSize 35 35 35
@@ -346,16 +348,23 @@ Tank : "{8A883ABED22B6E27}Prefabs/Vehicles/Core/Tracked_Base.et" {
      SlotTemplate InventoryStorageSlot Ammo {
       Prefab "{D8421F6E70B2FB4F}Prefabs/Weapons/Magazines/Box_762x54_PK_250rnd_4Ball_1Tracer.et"
      }
+     NumSlots 4
     }
     MultiSlotConfiguration "{5E38B925DD33F645}" {
      SlotTemplate InventoryStorageSlot CommanderAmmo {
       Prefab "{843D9B182BCD2765}Prefabs/Weapons/Magazines/NSV/Box_127x108_NSV_50rnd_4AP_1APIT.et"
      }
-     NumSlots 2
+     NumSlots 4
     }
     MultiSlotConfiguration "{5E38B925DD33F644}" {
      SlotTemplate InventoryStorageSlot "{5E157C7762407F59}" {
       Prefab "{D0C27FBCCA7C2205}Prefabs/Weapons/Magazines/2A46/Box_125mm_2A46_HE_20rnd.et"
+     }
+     NumSlots 1
+    }
+    MultiSlotConfiguration "{620CC9C2E5EF50C7}" {
+     SlotTemplate InventoryStorageSlot "{620CC9C2E69160D7}" {
+      Prefab "{33B2DFDCD0EBA3DB}Prefabs/Items/Equipment/Kits/RepairKit_01/RepairKit_01_wrench.et"
      }
      NumSlots 1
     }
@@ -1014,7 +1023,7 @@ Tank : "{8A883ABED22B6E27}Prefabs/Vehicles/Core/Tracked_Base.et" {
   VehicleAnimationComponent "{50B803EAA459B0AF}" {
    AnimGraph "{E5D9CB02597071F5}Assets/Vehicles/Wheeled/BTR70/workspaces/BTR70.agr"
    AnimInstance "{F2DBB12250B5F75A}Assets/Vehicles/Wheeled/BTR70/workspaces/BTR_vehicle.asi"
-   StartNode "VehicleMasterControl"
+   StartNode "MasterControl"
    AnimInjection AnimationAttachmentInfo "{5E38B925DD08A374}" {
     AnimGraph "{E5D9CB02597071F5}Assets/Vehicles/Wheeled/BTR70/workspaces/BTR70.agr"
     AnimInstance "{5F52A6DF918B0033}Assets/Vehicles/Wheeled/BTR70/workspaces/BTR_player.asi"
@@ -1028,7 +1037,6 @@ Tank : "{8A883ABED22B6E27}Prefabs/Vehicles/Core/Tracked_Base.et" {
    }
   }
  }
- coords -13.792 -1.314 -7.384
  m_eVehicleType VEHICLE
  m_fTrackSpeed 0.02
 }

--- a/Prefabs/Vehicles/Tracked/T-72A/VehParts/Turret/T72A_Turret.et
+++ b/Prefabs/Vehicles/Tracked/T-72A/VehParts/Turret/T72A_Turret.et
@@ -227,8 +227,6 @@ Turret : "{4AD877DEA242E512}Prefabs/Weapons/Core/Turret_Base.et" {
      m_fMovementDampingSpeed 8
      m_fVignetteMoveSpeed 16
      m_fMotionBlurScale 0
-     m_fRecoilTranslationTarget 0.001
-     m_fRecoilScaleTranslation 1
     }
    }
    SignalsSourceAccess SignalsSourceAccessClass "{5E122300A616F827}" {
@@ -353,4 +351,5 @@ Turret : "{4AD877DEA242E512}Prefabs/Weapons/Core/Turret_Base.et" {
    DeactivationDelay 2
   }
  }
+ coords 1298.924 38.096 2820.764
 }

--- a/Prefabs/Vehicles/Tracked/T-72B/T72B_FIA.et
+++ b/Prefabs/Vehicles/Tracked/T-72B/T72B_FIA.et
@@ -12,11 +12,6 @@ Tank : "{726286E1F9570EA1}Prefabs/Vehicles/Tracked/T-72B/T72B_base.et" {
   SCR_EditableVehicleComponent "{50DEB7C26B5EB312}" {
    m_UIInfo SCR_EditableVehicleUIInfo "{5298E609432D192D}" {
     m_sFaction "FIA"
-    m_aAuthoredLabels +{
-    }
-    m_aAutoLabels {
-     12 122 54
-    }
    }
   }
   SCR_VehicleFactionAffiliationComponent "{5882CBD9AC741CEC}" {
@@ -30,4 +25,5 @@ Tank : "{726286E1F9570EA1}Prefabs/Vehicles/Tracked/T-72B/T72B_base.et" {
    }
   }
  }
+ coords 127.803 0 1241.449
 }

--- a/Prefabs/Vehicles/Tracked/T-72B/T72B_FIA.et.meta
+++ b/Prefabs/Vehicles/Tracked/T-72B/T72B_FIA.et.meta
@@ -11,5 +11,7 @@ MetaFileClass {
   }
   EntityTemplateResourceClass HEADLESS : PC {
   }
+  EntityTemplateResourceClass PS5 : PC {
+  }
  }
 }

--- a/Prefabs/Vehicles/Tracked/T-72B/T72B_base.et.meta
+++ b/Prefabs/Vehicles/Tracked/T-72B/T72B_base.et.meta
@@ -1,5 +1,5 @@
 MetaFileClass {
- Name "{726286E1F9570EA1}Prefabs/Vehicles/Tracked/T-72A/T72B_base.et"
+ Name "{726286E1F9570EA1}Prefabs/Vehicles/Tracked/T-72B/T72B_base.et"
  Configurations {
   EntityTemplateResourceClass PC {
   }
@@ -10,6 +10,8 @@ MetaFileClass {
   EntityTemplateResourceClass PS4 : PC {
   }
   EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
   }
  }
 }

--- a/Prefabs/Vehicles/Tracked/T-72B/VehParts/ERA/T72B_Kontakt_Base.et
+++ b/Prefabs/Vehicles/Tracked/T-72B/VehParts/ERA/T72B_Kontakt_Base.et
@@ -7,18 +7,20 @@ GenericEntity : "{A507D9AE39652BD6}Prefabs/Vehicles/Core/Vehicle_Part_Base.et" {
   SCR_DamageManagerComponent "{3EBB276D48AFFF41}" {
    "Additional hit zones" {
     SCR_DestructibleHitzone ERA {
+     ColliderNames {
+     }
      HZDefault 1
-     MaxHealth 50
-     DamageReduction 6
-     DamageThreshold 1
+     MaxHealth 10
+     DamageReduction 20
+     DamageThreshold 8
      "Collision multiplier" 0
      "Melee multiplier" 0
-     "Kinetic multiplier" 0.01
+     "Kinetic multiplier" 1.2
      "Fragmentation multiplier" 0
-     "Explosive multiplier" 0.005
-     "Incendiary multiplier" 2
+     "Explosive multiplier" 1
+     "Incendiary multiplier" 1
      m_pDestructionHandler SCR_DestructionBaseHandler "{5584D7FD19D422CB}" {
-      m_bDisablePhysicsAfterDestroyed 0
+      m_bDisablePhysicsAfterDestroyed 1
      }
      m_sDestructionSoundEvent "SOUND_EXPLOSION"
      m_sDestructionParticle "{728768DE31C8D1DE}Particles/Weapon/Explosion_VOG25.ptc"
@@ -27,4 +29,5 @@ GenericEntity : "{A507D9AE39652BD6}Prefabs/Vehicles/Core/Vehicle_Part_Base.et" {
    }
   }
  }
+ coords 1295.833 37.75 2858.003
 }

--- a/Prefabs/Weapons/Explosives/Mine_M15AT/AmmoRack_T72.et
+++ b/Prefabs/Weapons/Explosives/Mine_M15AT/AmmoRack_T72.et
@@ -4,5 +4,9 @@ GenericEntity : "{49FFE8F373F55961}Prefabs/Weapons/Explosives/Mine_M15AT/AmmoRac
   MeshObject "{5968D9C73C08706E}" {
    Object "{E684304AEF99FB07}Assets/Vehicles/Tracked/T-72A/AmmoRack.xob"
   }
+  SCR_MineInventoryItemComponent "{59E4E694B93DC656}" {
+   Enabled 0
+  }
  }
+ coords 1296.206 37.75 2854.669
 }

--- a/Prefabs/Weapons/HeavyWeapons/2A46/Cannon_2A46.et
+++ b/Prefabs/Weapons/HeavyWeapons/2A46/Cannon_2A46.et
@@ -56,7 +56,12 @@ GenericEntity : "{E1F14DB52DBFBC57}Prefabs/Weapons/Core/Weapon_Base.et" {
   }
   WeaponComponent "{CFBAA4B706BA66E8}" {
    components {
-    SightsComponent "{BB23A637957CFFF8}" {
+    AttachmentSlotComponent "{621CE29CF07B113C}" {
+     AttachmentSlot InventoryStorageSlot "{621CE29CED006BC1}" {
+      PivotID "slot_optics"
+      ChildPivotID "snap_weapon"
+      Enabled 0
+     }
     }
     MuzzleComponent "{5E1425A1AA3199A6}" {
      components {
@@ -193,12 +198,15 @@ GenericEntity : "{E1F14DB52DBFBC57}Prefabs/Weapons/Core/Weapon_Base.et" {
       }
      }
      ReloadDuration 7
+     AllowWeaponDeployment 0
      MagazinePosition InventoryStorageSlot Mag {
       Offset -0.3583 0.0384 -0.0656
+      ChildPivotID "snap_weapon"
      }
      MagazineTemplate "{2103601E9C5BDD5B}Prefabs/Weapons/Magazines/2A46/Box_125mm_2A46_APFSDS_20rnd.et"
     }
     WeaponAnimationComponent "{60B4EA76EB15F6E0}" {
+     Enabled 0
      AnimGraph "{5C41727F96285D4E}Assets/Weapons/MachineGuns/workspaces/M249.agr"
      AnimInstance "{E2DF83DEEE9355A1}Assets/Weapons/HeavyWeapons/workspaces/Cannon_weapon.asi"
      AlwaysActive 1
@@ -238,5 +246,5 @@ GenericEntity : "{E1F14DB52DBFBC57}Prefabs/Weapons/Core/Weapon_Base.et" {
    AllowCrossHierarchy 1
   }
  }
- coords 0 0 0
+ coords 1283.548 37.938 2825.677
 }

--- a/Prefabs/Weapons/Magazines/2A46/Box_125mm_2A46_APFSDS_20rnd.et
+++ b/Prefabs/Weapons/Magazines/2A46/Box_125mm_2A46_APFSDS_20rnd.et
@@ -25,7 +25,7 @@ GenericEntity : "{F9E1A46E3ABA116F}Prefabs/Weapons/Core/Magazine_Base.et" {
     Name "2A46 3BM15 APFSDS"
     Description ""
     m_sAmmoCaliber "125mm"
-    m_sAmmoType "APFSDS"
+    m_sAmmoType "3BM15 APFSDS"
     m_bShowAmmoTypeText 1
     m_eAmmoTypeFlags 6
    }
@@ -50,4 +50,5 @@ GenericEntity : "{F9E1A46E3ABA116F}Prefabs/Weapons/Core/Magazine_Base.et" {
    AllowCrossHierarchy 1
   }
  }
+ coords 1294.234 37.969 2831.912
 }

--- a/Prefabs/Weapons/Magazines/2A46/Box_125mm_2A46_HE_20rnd.et
+++ b/Prefabs/Weapons/Magazines/2A46/Box_125mm_2A46_HE_20rnd.et
@@ -16,7 +16,7 @@ GenericEntity : "{2103601E9C5BDD5B}Prefabs/Weapons/Magazines/2A46/Box_125mm_2A46
   MagazineComponent "{CA6BE4D6B4DAFD69}" {
    UIInfo MagazineUIInfo "{57126733AA401586}" {
     Name "2A46 3OF26 HE"
-    m_sAmmoType "HE"
+    m_sAmmoType "3OF26 HE"
     m_eAmmoTypeFlags 40
    }
    AmmoMapping {
@@ -24,4 +24,5 @@ GenericEntity : "{2103601E9C5BDD5B}Prefabs/Weapons/Magazines/2A46/Box_125mm_2A46
    }
   }
  }
+ coords 1297.953 37.969 2831.325
 }


### PR DESCRIPTION
-Change label to APC to make it spawnable in conflict more easily -Make ERA more easily destructible( similar to RHS era setup) -Add more MG ammo to T-72 inventory
-Disable WeaponAnimationComponent on some weapon
-Add ammo name to 125mm magazine